### PR TITLE
add sha256 for arm64, in addition to amd64

### DIFF
--- a/Formula/kubectl.rb
+++ b/Formula/kubectl.rb
@@ -16,6 +16,10 @@ class Kubectl < Formula
     url 'https://github.com/OpsLevel/kubectl-opslevel/archive/refs/tags/v2024.3.4.tar.gz'
     sha256 '27480caca25a8d3634d5550a2362536102fa43c62aa87bf33bf2b5fac37b002c'
 
+    if Hardware::CPU.arm?
+      sha256 '15bda9c278ac72fd9209999fffeb345f0a21551d3ed7237812c95fdb0bbf6d7f'
+    end
+
     def install
       ENV['CGO_ENABLED'] = '1'
       ENV['CGO_CFLAGS'] = "-I#{Formula['jq'].opt_include}"


### PR DESCRIPTION
Currently, when `kubectl-opslevel` is released there is one sha256 known to `brew`.

`brew install opslevel/tap/kubectl` was only working for either `amd64` machines or `arm64`. Not both, this fixes that right away and there is some extra work needed upstream.

Part of [this ticket](https://github.com/OpsLevel/team-platform/issues/260)