### PR TITLE
reuse version, try git commit hash

### DIFF
--- a/Formula/kubectl.rb
+++ b/Formula/kubectl.rb
@@ -21,7 +21,7 @@ class Kubectl < Formula
     cd 'src' do
       system 'go', 'build', *std_go_args(
         output: bin / 'kubectl-opslevel',
-        ldflags: "-s -w -X main.version=#{version.major_minor_patch} -X main.commit=#{Utils.git_short_head}"
+        ldflags: "-s -w -X main.version=#{version.major_minor_patch} -X main.commit=4f8a77404a4b"
       )
     end
   end

--- a/Formula/kubectl.rb
+++ b/Formula/kubectl.rb
@@ -10,7 +10,7 @@ class Kubectl < Formula
   depends_on 'go'
   depends_on 'jq'
 
-  url 'https://github.com/OpsLevel/kubectl-opslevel/archive/refs/tags/v2024.3.18.tar.gz'
+  url "https://github.com/OpsLevel/kubectl-opslevel/archive/refs/tags/v#{version.major_minor_patch}.tar.gz"
   sha256 'c4696b440b28548f376d1a9f5eaa5bb11b643e1f22beaa140ddf2a9eaf8aeb1c'
 
   def install
@@ -19,8 +19,10 @@ class Kubectl < Formula
     ENV['CGO_LDFLAGS'] = "-L#{Formula['jq'].opt_lib}"
 
     cd 'src' do
-      system 'go', 'build', *std_go_args(output: bin / 'kubectl-opslevel',
-                                         ldflags: '-s -w -X main.version=2024.3.18 -X main.commit=4f8a77404a4b')
+      system 'go', 'build', *std_go_args(
+        output: bin / 'kubectl-opslevel',
+        ldflags: "-s -w -X main.version=#{version.major_minor_patch} -X main.commit=#{Utils.git_short_head}"
+      )
     end
   end
 


### PR DESCRIPTION
Use brew's internal utils to reduce (or drop) `awk` usage in our release process.
`#{version.major_minor_patch}` works great, tested this locally.
I couldn't test `#{Utils.git_short_head}` locally, but I saw its use in other repos and we can yank it out if this fails.