### PR TITLE
update tag to try to get brew bump-formula-pr to work

### DIFF
--- a/Formula/kubectl.rb
+++ b/Formula/kubectl.rb
@@ -11,7 +11,7 @@ class Kubectl < Formula
   depends_on 'jq'
 
   url 'https://github.com/OpsLevel/kubectl-opslevel.git',
-      tag: "v#{version.major_minor_patch}",
+      tag: 'v2024.3.18',
       revision: '4f8a77404a4b285716c94912007753ea02e6d539'
   sha256 'c4696b440b28548f376d1a9f5eaa5bb11b643e1f22beaa140ddf2a9eaf8aeb1c'
 


### PR DESCRIPTION
Below is what I'm trying to get working. I wonder if this part `v#{version.major_minor_patch}"` is confusing the command

```bash
brew bump-formula-pr --verbose --no-audit --no-browse --write-only --message="Brew formula update for kubectl-opslevel version v2024.4.3" --version="2024.4.3" --tag="v2024.4.3" --revision="9114eb73696ee84c9bc57b91fed9066ab98875f1" opslevel/tap/kubectl

==> replace /tag:(\s+")v2024.3.18(?=")/ with "tag:\\1v2024.4.3\\2"
==> replace "4f8a77404a4b285716c94912007753ea02e6d539" with "9114eb73696ee84c9bc57b91fed9066ab98875f1"
==> replace /^( {2})( +)(:revision => "9114eb73696ee84c9bc57b91fed9066ab98875f1"\n)/m with "\\1\\2\\3\\1version \"2024.4.3\"\n"
Error: inreplace failed
/opt/homebrew/Library/Taps/opslevel/homebrew-tap/Formula/kubectl.rb:
  expected replacement of /tag:(\s+")v2024.3.18(?=")/ with "tag:\\1v2024.4.3\\2"
  expected replacement of /^( {2})( +)(:revision => "9114eb73696ee84c9bc57b91fed9066ab98875f1"\n)/m with "\\1\\2\\3\\1version \"2024.4.3\"\n"

```