### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -4,6 +4,8 @@ on:
   push:
     branches: [ main ]
 
+permissions:
+  contents: read
 
 jobs:
   release:

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -1,5 +1,8 @@
 name: Security
 
+permissions:
+  contents: read
+
 on:
   workflow_dispatch: {}
   schedule:


### PR DESCRIPTION
Potential fix for [https://github.com/OpsLevel/homebrew-tap/security/code-scanning/2](https://github.com/OpsLevel/homebrew-tap/security/code-scanning/2)

To fix the issue, we will add a `permissions` block at the root of the workflow file. This block will define the minimal permissions required for the workflow to function. Based on the provided example, we will set `contents: read` as a starting point, as the workflow does not appear to require write access. If additional permissions are needed, they can be added explicitly.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
